### PR TITLE
condition on type-or-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To run the tests:
 
 Use from your Leiningen project:
 
-    [rdf-clj "0.1.0"]
+    [rdf-clj "0.2.0-SNAPSHOT"]
 
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,23 +1,17 @@
-(defproject rdf-clj "0.2.0-SNAPSHOT"
+(defproject org.clojars.phreed/rdf-clj "0.2.0-SNAPSHOT"
   :description "RDF for Clojure, integrates with Commons RDF, Jena, RDF4J"
-  :url "https://github.com/stain/rdf-clj"
+  :url "https://github.com/phreed/rdf-clj"
   :license {:name "Apache License, version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apache.commons/commons-rdf-api "0.3.0-incubating"]
-                 [org.apache.commons/commons-rdf-simple "0.3.0-incubating"]
-
+                 [org.apache.commons/commons-rdf-api "0.5.0"]
+                 [org.apache.commons/commons-rdf-simple "0.5.0"]]
 ;                [potemkin "0.3.13"]
 
-                ]
-
   :profiles {
-    :dev {
-      :dependencies [[org.apache.commons/commons-rdf-jena "0.3.0-incubating"]
-                   [org.apache.commons/commons-rdf-rdf4j "0.3.0-incubating"]
-                   [org.apache.commons/commons-rdf-jsonld-java "0.3.0-incubating"]
-                  ]
-                }
-              }
+             :dev {
+                   :dependencies [[org.apache.commons/commons-rdf-jena "0.5.0"]
+                                  [org.apache.commons/commons-rdf-rdf4j "0.5.0"]
+                                  [org.apache.commons/commons-rdf-jsonld-java "0.5.0"]]}})
+
 ;  :repositories { "apache-snapshot" "http://repository.apache.org/snapshots"}
-)

--- a/src/rdf/commonsrdf.clj
+++ b/src/rdf/commonsrdf.clj
@@ -45,11 +45,11 @@
   p/Graph
     (add-triple
       ([g tripl]
-       (.add g (p/triple (simpleRDF) tripl)
-        g)) ; Return same instance
+       (.add g (p/triple (simpleRDF) tripl))
+       g) ; Return same instance
       ([g subj pred obj]
-       (.add g (p/triple (simpleRDF) subj pred obj)
-        g)))
+       (.add g (p/triple (simpleRDF) subj pred obj))
+       g))
     (remove-triple
       ([g tripl]
        (.remove g (p/triple (simpleRDF) tripl))

--- a/src/rdf/commonsrdf.clj
+++ b/src/rdf/commonsrdf.clj
@@ -12,8 +12,8 @@
   (keyword (last (clojure.string/split
     ; Last part of implementation class package name, e.g.
     ; org.apache.commons.rdf.simple.SimpleRDF -> :simple
-    (.getName (.getPackage (class rdf)))
-     #"\." ))))
+                  (.getName (.getPackage (class rdf)))
+                  #"\."))))
 
 (defn- simpleRDF [] (SimpleRDF.))
 
@@ -28,43 +28,43 @@
 
 (defn- rdf-impls-seq []
   (iterator-seq (.iterator
-    (java.util.ServiceLoader/load RDF))))
+                 (java.util.ServiceLoader/load RDF))))
 
 (defn rdf-impls []
   (apply hash-map (mapcat #(list (key-for-rdf-impl %1) %1)
-    (rdf-impls-seq))))
+                   (rdf-impls-seq))))
 
 (defn rdf-impl
   ([] (first (rdf-impls-seq)))
   ([k]
-    (if (= :simple k) (simpleRDF) ; no need for ServiceLoader and mapping
-      (get (rdf-impls) (keyword k)))))
+   (if (= :simple k) (simpleRDF) ; no need for ServiceLoader and mapping
+     (get (rdf-impls) (keyword k)))))
 
 
 (extend-type Graph
   p/Graph
     (add-triple
       ([g tripl]
-        (.add g (p/triple (simpleRDF) tripl)
+       (.add g (p/triple (simpleRDF) tripl)
         g)) ; Return same instance
       ([g subj pred obj]
-        (.add g (p/triple (simpleRDF) subj pred obj)
+       (.add g (p/triple (simpleRDF) subj pred obj)
         g)))
     (remove-triple
       ([g tripl]
-        (.remove g (p/triple (simpleRDF) tripl))
-        g)
+       (.remove g (p/triple (simpleRDF) tripl))
+       g)
       ([g subj pred obj]
-        (.remove g (termPattern subj) (termPattern pred) (termPattern obj))
-        g))
+       (.remove g (termPattern subj) (termPattern pred) (termPattern obj))
+       g))
     (contains-triple?
       ([g tripl]
-        (.contains g (p/triple (simpleRDF) tripl)))
+       (.contains g (p/triple (simpleRDF) tripl)))
       ([g subj pred obj]
-        (.contains g (termPattern subj) (termPattern pred) (termPattern obj))))
+       (.contains g (termPattern subj) (termPattern pred) (termPattern obj))))
     (triple-count [g]
-      (.size g))
-)
+      (.size g)))
+
 
 
 (extend-type Triple
@@ -79,31 +79,31 @@
     (graph
         ([f] (.createGraph f))
         ([f g] (if-instance Graph g
-          (reduce p/add-triple (p/graph f) g))))
+                (reduce p/add-triple (p/graph f) g))))
     (iri [f iri] (if-instance IRI iri (.createIRI f (p/iri-str iri))))
     (literal
       ([f lit]
-        (if-instance Literal lit) (.createLiteral f (p/literal-str lit)))
+       (if-instance Literal lit) (.createLiteral f (p/literal-str lit)))
       ([f lit type-or-lang]
-        (.createLiteral f (str lit)
-          (if (p/iri? type-or-lang)
-            (p/iri f type-or-lang)) ; must be type
-            (name type-or-lang))); must be non-nil lang
+       (.createLiteral f (str lit)
+         (if (p/iri? type-or-lang)
+           (p/iri f type-or-lang) ; must be type
+           (name type-or-lang)))); must be non-nil lang
       ([f lit type lang]
-        (if (nil? lang)
-          (.createLiteral f (str lit) (p/iri f type))
-          (.createLiteral f (str lit) (p/iri f type) (name lang)))))
+       (if (nil? lang)
+         (.createLiteral f (str lit) (p/iri f type))
+         (.createLiteral f (str lit) (p/iri f type) (name lang)))))
 
     (blanknode
       ([f]
-        (.createBlankNode f))
+       (.createBlankNode f))
       ([f name]
-        (.createBlankNode f (str name))))
+       (.createBlankNode f (str name))))
     (triple
       ([f t]
-        (if-instance Triple t (.createTriple f (p/subject t) (p/predicate t) (p/object t))))
-      ([f subj pred obj] (.createTriple f subj pred obj))) ;; TODO: Type conversion
-)
+       (if-instance Triple t (.createTriple f (p/subject t) (p/predicate t) (p/object t))))
+      ([f subj pred obj] (.createTriple f subj pred obj)))) ;; TODO: Type conversion
+
 
 
 (extend-type RDFTerm p/Term


### PR DESCRIPTION
The misplaced parenthesis introduces an excess argument.
See lines 88-91.
```
(.createLiteral f (str lit)
    (if (p/iri? type-or-lang)
        (p/iri f type-or-lang)    **)**  ; must be type
        (name type-or-lang))); must be non-nil lang
```